### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Lint & Check Types & Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/monok8i/python-boilerplate/security/code-scanning/2](https://github.com/monok8i/python-boilerplate/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs basic CI tasks (linting, type checking, and testing), it requires minimal permissions. The `contents: read` permission is sufficient for these tasks. This change will limit the `GITHUB_TOKEN` to read-only access to the repository contents, reducing the risk of unauthorized actions.

The `permissions` block should be added at the root level of the workflow, ensuring it applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
